### PR TITLE
Fix GeoJSON files containing features with a null geometry

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var coordEach = require('turf-meta').coordEach;
+var coordEach = require('@turf/meta').coordEach;
 
 module.exports = {
     addElevation: function(geojson, elevationProvider, cb, nodata) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,19 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@turf/helpers": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz",
+      "integrity": "sha512-vJvrdOZy1ngC7r3MDA7zIGSoIgyrkWcGnNIEaqn/APmw+bVLF2gAW7HIsdTxd12s5wQMqEpqIQrmrbRRZ0xC7g=="
+    },
+    "@turf/meta": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.0.2.tgz",
+      "integrity": "sha512-VA7HJkx7qF1l3+GNGkDVn2oXy4+QoLP6LktXAaZKjuT1JI0YESat7quUkbCMy4zP9lAUuvS4YMslLyTtr919FA==",
+      "requires": {
+        "@turf/helpers": "6.1.4"
+      }
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -969,11 +982,6 @@
       "requires": {
         "safe-buffer": "5.1.1"
       }
-    },
-    "turf-meta": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/turf-meta/-/turf-meta-3.0.12.tgz",
-      "integrity": "sha1-CqmhyvgrKloI1U4IMLW1o/oOijg="
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "node-hgt": "^1.2.2",
-    "turf-meta": "^3.0.1"
+    "@turf/meta": "^6.0.2"
   },
   "devDependencies": {
     "tap-spec": "^4.1.1",

--- a/test/spec.js
+++ b/test/spec.js
@@ -1,7 +1,7 @@
 var test = require('tape'),
     addElevation = require('../').addElevation,
     TileSet = require('node-hgt').TileSet,
-    coordReduce = require('turf-meta').coordReduce;
+    coordReduce = require('@turf/meta').coordReduce;
 
 test('can add elevation to LineString', function(t) {
     var lineString = {


### PR DESCRIPTION
Fix GeoJSON files containing features with a null geometry by upgrading turf-meta 3.0.12 to @turf/meta 6.0.2.   The turf-meta 3.0.12 package throws an exception on null geometries.